### PR TITLE
Update Next.js to 16.2.6

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import type { ReactNode } from "react";
 import Image from "next/image";
 import { Providers } from "../providers";
 import { LayoutWithHeader } from "@/components/async/layout-with-header";
@@ -14,7 +14,7 @@ export default async function Layout({
 	children,
 	params,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 	params: Promise<{ lang: string }>;
 }) {
 	await params;

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type React from "react";
 import Image from "next/image";
 import { Providers } from "../providers";
 import { LayoutWithHeader } from "@/components/async/layout-with-header";
@@ -14,14 +14,14 @@ export default async function Layout({
 	children,
 	params,
 }: {
-	children: ReactNode;
+	children: React.ReactNode;
 	params: Promise<{ lang: string }>;
 }) {
 	await params;
 	const session = await requireAuth();
 
 	return (
-		<Providers userEmail={session.user.email}>
+		<Providers>
 			<CachedDataWrapper>
 				<LayoutWithHeader
 					title="Agricolala"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { headers } from "next/headers";
-import type React from "react";
+import type { ReactNode } from "react";
 import "./globals.css";
 import { defaultLocale, LOCALE_HEADER } from "@/lib/translations-helpers";
 import { inter } from "./const";
@@ -18,7 +18,7 @@ export const viewport: Viewport = {
 export default async function RootLayout({
 	children,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 }) {
 	const headersList = await headers();
 	const lang = headersList.get(LOCALE_HEADER) ?? defaultLocale;

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { TosCheck } from "@/components/legal/tos-check";
-import type React from "react";
+import type { ReactNode } from "react";
 import { TranslationsProvider } from "@/contexts/translations-context";
 
 export function Providers({
 	children,
 	userEmail,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 	userEmail?: string | null;
 }) {
 	return (

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,16 +4,10 @@ import { TosCheck } from "@/components/legal/tos-check";
 import type { ReactNode } from "react";
 import { TranslationsProvider } from "@/contexts/translations-context";
 
-export function Providers({
-	children,
-	userEmail,
-}: {
-	children: ReactNode;
-	userEmail?: string | null;
-}) {
+export function Providers({ children }: { children: ReactNode }) {
 	return (
 		<TranslationsProvider>
-			<TosCheck userEmail={userEmail}>{children}</TosCheck>
+			<TosCheck>{children}</TosCheck>
 		</TranslationsProvider>
 	);
 }

--- a/components/async/layout-with-header.tsx
+++ b/components/async/layout-with-header.tsx
@@ -1,21 +1,21 @@
-import type React from "react";
+import type { ReactNode } from "react";
 import { BottomNavigation } from "../routing/bottom-navigation";
 import { UnauthorizedMessage } from "../misc/unauthorized-message";
 import { SidebarNavigation } from "../routing/sidebar-navigation";
 
 interface LayoutWithHeaderProps {
-	children: React.ReactNode;
-	icon: React.ReactNode;
+	children: ReactNode;
+	icon: ReactNode;
 	title: string;
 	isAuthorized: boolean;
 }
 
-export const LayoutWithHeader: React.FC<LayoutWithHeaderProps> = async ({
+export const LayoutWithHeader = async ({
 	children,
 	icon,
 	title,
 	isAuthorized,
-}) => {
+}: LayoutWithHeaderProps) => {
 	if (!isAuthorized) {
 		return <UnauthorizedMessage />;
 	}

--- a/components/legal/tos-check.tsx
+++ b/components/legal/tos-check.tsx
@@ -8,33 +8,30 @@ import { useRouter } from "next/navigation";
 
 interface TosCheckProps {
 	children: React.ReactNode;
-	userEmail?: string | null;
 }
 
-export function TosCheck({ children, userEmail }: TosCheckProps) {
+export function TosCheck({ children }: TosCheckProps) {
 	const [showTosDialog, setShowTosDialog] = useState(false);
 	const [isChecking, setIsChecking] = useState(true);
 	const router = useRouter();
 
 	useEffect(() => {
 		const checkTosAcceptance = async () => {
-			if (userEmail) {
-				try {
-					const result = await getTosStatus();
+			try {
+				const result = await getTosStatus();
 
-					if (result.success && !result.tosAccepted) {
-						setShowTosDialog(true);
-					}
-				} catch (error) {
-					console.error("Error checking ToS status:", error);
+				if (result.success && !result.tosAccepted) {
+					setShowTosDialog(true);
 				}
+			} catch (error) {
+				console.error("Error checking ToS status:", error);
 			}
 
 			setIsChecking(false);
 		};
 
 		checkTosAcceptance();
-	}, [userEmail]);
+	}, []);
 
 	const handleAcceptTos = async () => {
 		try {

--- a/components/parcels/add-parcel-dialog.tsx
+++ b/components/parcels/add-parcel-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import type React from "react";
 import { useEffect, useState } from "react";
 import { useTranslations } from "@/contexts/translations-context";
 import { Button } from "@/components/ui/button";

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	experimental: {
-		taint: process.env.NODE_ENV !== "production",
+		taint: true,
 		serverActions: {
 			allowedOrigins: ["agricolala-eta.vercel.app", "*.agricolala-eta.vercel.app"],
 		},
@@ -17,7 +17,12 @@ const nextConfig = {
 	},
 	serverExternalPackages: ["@prisma/client"],
 	images: {
-		domains: ["lh3.googleusercontent.com"],
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "lh3.googleusercontent.com",
+			},
+		],
 	},
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
 				"@types/react-dom": "^19",
 				"@vitejs/plugin-react": "^4.6.0",
 				"eslint": "9.30.0",
-				"eslint-config-next": "16.1.6",
+				"eslint-config-next": "^16.2.6",
 				"husky": "^9.1.7",
 				"jsdom": "^26.1.0",
 				"postcss": "^8.5",
@@ -2193,9 +2193,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
-			"version": "16.1.6",
-			"resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
-			"integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+			"integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6958,13 +6958,13 @@
 			}
 		},
 		"node_modules/eslint-config-next": {
-			"version": "16.1.6",
-			"resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
-			"integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
+			"integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@next/eslint-plugin-next": "16.1.6",
+				"@next/eslint-plugin-next": "16.2.6",
 				"eslint-import-resolver-node": "^0.3.6",
 				"eslint-import-resolver-typescript": "^3.5.2",
 				"eslint-plugin-import": "^2.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 				"leaflet": "^1.9.4",
 				"lucide-react": "^0.525.0",
 				"negotiator": "^1.0.0",
-				"next": "^15.5.18",
+				"next": "^16.2.6",
 				"next-auth": "latest",
 				"next-themes": "^0.4.4",
 				"prisma": "latest",
@@ -2187,9 +2187,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
-			"integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+			"integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
@@ -2203,9 +2203,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
-			"integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+			"integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2219,9 +2219,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
-			"integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+			"integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2235,9 +2235,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
-			"integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+			"integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2251,9 +2251,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
-			"integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+			"integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2267,9 +2267,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
-			"integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+			"integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
 			"cpu": [
 				"x64"
 			],
@@ -2283,9 +2283,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
-			"integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+			"integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
 			"cpu": [
 				"x64"
 			],
@@ -2299,9 +2299,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
-			"integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+			"integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2315,9 +2315,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
-			"integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+			"integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
 			"cpu": [
 				"x64"
 			],
@@ -5861,6 +5861,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.33",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+			"integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
@@ -9261,13 +9273,14 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
-			"integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+			"integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.5.18",
+				"@next/env": "16.2.6",
 				"@swc/helpers": "0.5.15",
+				"baseline-browser-mapping": "^2.9.19",
 				"caniuse-lite": "^1.0.30001579",
 				"postcss": "8.4.31",
 				"styled-jsx": "5.1.6"
@@ -9276,18 +9289,18 @@
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.5.18",
-				"@next/swc-darwin-x64": "15.5.18",
-				"@next/swc-linux-arm64-gnu": "15.5.18",
-				"@next/swc-linux-arm64-musl": "15.5.18",
-				"@next/swc-linux-x64-gnu": "15.5.18",
-				"@next/swc-linux-x64-musl": "15.5.18",
-				"@next/swc-win32-arm64-msvc": "15.5.18",
-				"@next/swc-win32-x64-msvc": "15.5.18",
-				"sharp": "^0.34.3"
+				"@next/swc-darwin-arm64": "16.2.6",
+				"@next/swc-darwin-x64": "16.2.6",
+				"@next/swc-linux-arm64-gnu": "16.2.6",
+				"@next/swc-linux-arm64-musl": "16.2.6",
+				"@next/swc-linux-x64-gnu": "16.2.6",
+				"@next/swc-linux-x64-musl": "16.2.6",
+				"@next/swc-win32-arm64-msvc": "16.2.6",
+				"@next/swc-win32-x64-msvc": "16.2.6",
+				"sharp": "^0.34.5"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"leaflet": "^1.9.4",
 		"lucide-react": "^0.525.0",
 		"negotiator": "^1.0.0",
-		"next": "^15.5.18",
+		"next": "^16.2.6",
 		"next-auth": "latest",
 		"next-themes": "^0.4.4",
 		"prisma": "latest",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"@types/react-dom": "^19",
 		"@vitejs/plugin-react": "^4.6.0",
 		"eslint": "9.30.0",
-		"eslint-config-next": "16.1.6",
+		"eslint-config-next": "^16.2.6",
 		"husky": "^9.1.7",
 		"jsdom": "^26.1.0",
 		"postcss": "^8.5",

--- a/proxy.ts
+++ b/proxy.ts
@@ -31,8 +31,8 @@ function getLocaleFromHeaders(request: Request): Locale {
 	return matchedLocale;
 }
 
-export default withAuth(
-	function middleware(req) {
+export const proxy = withAuth(
+	function proxy(req) {
 		const { pathname } = req.nextUrl;
 		const token = req.nextauth.token;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"noUnusedLocals": true,
-		"jsx": "preserve",
+		"jsx": "react-jsx",
 		"incremental": true,
 		"plugins": [
 			{
@@ -23,6 +23,12 @@
 			"@/*": ["./*"]
 		}
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
+	],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Updates `next` from `^15.5.18` to `^16.2.6` and refreshes `package-lock.json`.
- Aligns `eslint-config-next` and `@next/eslint-plugin-next` with Next 16.2.6.
- Enables the React taint experiment for Next 16 builds and replaces deprecated `images.domains` with `images.remotePatterns`.
- Accepts Next 16's React automatic JSX runtime TypeScript settings and removes obsolete `React` namespace imports.
- Renames the route interception convention from `middleware.ts` to `proxy.ts`.
- Fixes the credentials login runtime error by no longer passing the tainted test email into the client ToS wrapper.

### Walkthrough
[seeded_login_success.mp4](https://cursor.com/agents/bc-b7a0dfea-7ec1-48f5-8e93-6269ad4d7307/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseeded_login_success.mp4)

### Testing
- `npx prisma migrate dev && npm run seed` passes against local PostgreSQL.
- `npm ls next eslint-config-next @next/eslint-plugin-next --depth=0` shows `next@16.2.6` and `eslint-config-next@16.2.6`.
- `npm run lint` passes with one existing warning in `hooks/use-toast.ts`.
- `npm run tsc` passes.
- `npx biome check .` passes.
- `npm run build` passes with the generated ignored local `.env`.
- Manual browser login passes after seed: credentials sign-in, ToS acceptance, and authenticated `/en` home page load without runtime error.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7a0dfea-7ec1-48f5-8e93-6269ad4d7307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7a0dfea-7ec1-48f5-8e93-6269ad4d7307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

