### PR TITLE
Add Playwright e2e coverage

### DIFF
--- a/.agents/skills/caveman/README.md
+++ b/.agents/skills/caveman/README.md
@@ -1,0 +1,48 @@
+# caveman
+
+Talk like smart caveman. Same brain, fewer tokens.
+
+## What it does
+
+Compress every model response to caveman-style prose. Drops articles, filler, pleasantries, and hedging. Keeps every technical detail, code block, error string, and symbol exact. Cuts ~65-75% of output tokens with full accuracy preserved. Mode persists for the whole session until changed or stopped.
+
+Six intensity levels:
+
+| Level | What change |
+|-------|-------------|
+| `lite` | Drop filler/hedging. Sentences stay full. Professional but tight. |
+| `full` | Default. Drop articles, fragments OK, short synonyms. |
+| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). Arrows for causality. |
+| `wenyan-lite` | Classical Chinese register, light compression. |
+| `wenyan-full` | Maximum 文言文. 80-90% character reduction. |
+| `wenyan-ultra` | Extreme classical compression. |
+
+Auto-clarity rule: caveman drops to normal prose for security warnings, irreversible-action confirmations, multi-step sequences where fragment ambiguity risks misread, and when user repeats a question. Resumes after the clear part.
+
+## How to invoke
+
+```
+/caveman              # full mode (default)
+/caveman lite         # lighter compression
+/caveman ultra        # extreme compression
+/caveman wenyan       # classical Chinese
+stop caveman          # back to normal prose
+```
+
+## Example output
+
+Question: "Why does my React component re-render?"
+
+Normal prose:
+> Your component re-renders because you create a new object reference each render. Wrapping it in `useMemo` will fix the issue.
+
+Caveman (full):
+> New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
+
+Caveman (ultra):
+> Inline obj prop → new ref → re-render. `useMemo`.
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview, install, benchmarks

--- a/.agents/skills/caveman/SKILL.md
+++ b/.agents/skills/caveman/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate prose words (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough. Code symbols, function names, API names, error strings: never abbreviate |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
+- wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,63 @@ jobs:
           path: |
             test-results/
             coverage/
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: agraria
+          POSTGRES_PASSWORD: agraria
+          POSTGRES_DB: agraria
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5434:5432
+
+    env:
+      DATABASE_URL: postgresql://agraria:agraria@localhost:5434/agraria?schema=public
+      DIRECT_URL: postgresql://agraria:agraria@localhost:5434/agraria?schema=public
+      NEXTAUTH_URL: http://127.0.0.1:3002
+      NEXTAUTH_SECRET: test-nextauth-secret
+      TEST_USER_EMAIL: playwright@agricolala.test
+      TEST_USER_PASSWORD: playwright-local-password
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Generate Prisma Client
+        run: npx -y prisma generate
+
+      - name: Run database migrations
+        run: npx -y prisma migrate deploy
+
+      - name: Run Playwright e2e tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: |
+            test-results/
+            playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+e2e/.auth/
+test-results/
+playwright-report/
 
 # env files
 *.env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ npm run test:e2e
 npm run test:e2e:db:stop
 ```
 
-The e2e setup uses `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets that e2e database, seeds an authorized test user, one Cinque Terre parcel in Liguria, and four April treatments for the dashboard chart, then logs in through the credentials form. Do not point these tests at a development or production database unless you intentionally set `ALLOW_E2E_DB_RESET=true`.
+The e2e setup uses `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets that e2e database, seeds an authorized test user, one Cinque Terre parcel in Liguria, and four April treatments for the dashboard chart, then logs in through the credentials form. The reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
 
 When writing Playwright tests, prefer accessible selectors in this order: `getByRole` with a name, `getByLabel`, `getByPlaceholder`, and visible text. Avoid `getByTestId` unless there is no practical accessible surface; if a test needs one, first consider improving the component semantics with labels, roles, or accessible names.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,103 +1,157 @@
 # AGENTS.md
 
-## Cursor Cloud specific instructions
+Instructions for **AI coding agents** in this repo (**Cursor Cloud** or **local Cursor/IDE**). Step-by-step human setup: [readme.md](readme.md).
 
-### Overview
+## Choose your environment
 
-Agricolala is a Next.js 15 + React 19 web app for managing vineyard treatments and tracking substance usage for organic EU compliance. Uses Prisma ORM with PostgreSQL, Google OAuth via NextAuth, and is deployed on Vercel.
+| Where you run | Dev database | Vitest | Playwright e2e |
+|---------------|--------------|--------|----------------|
+| **Cursor Cloud** | Native PG 16, `agraria` @ `5432` | `npm run test` → `agraria_test` @ `5432` | `npm run test:e2e:agent` → `agraria_e2e` — **no Docker** |
+| **Local** | `docker compose up` → `agraria` @ `5435` | `npm run test:db:start` → `5433`; then `npm run test` | `test:e2e:db:start` → `npm run test:e2e` → `test:e2e:db:stop` |
 
-### Database
+**CI** (`.github/workflows/test.yml`, same ports as **Local** Docker):
 
-PostgreSQL 16 is installed natively (not Docker, to avoid Docker Hub rate limits). The `agraria` user has superuser privileges (needed for integration tests that set `session_replication_role`).
+- **Vitest job:** Postgres 15 service on `5433`, `npm run test` (no `test:db:start` script)
+- **E2e job:** Postgres 15 service on `5434`, `npm run test:e2e`
 
-- Dev database: `agraria` on `localhost:5432`
-- Test database: `agraria_test` on `localhost:5432`
+### Which row am I?
 
-To start PostgreSQL if it's not running:
-```
-sudo pg_ctlcluster 16 main start
-```
+| You are… | Row |
+|----------|-----|
+| Agent in **Cursor Cloud** (remote Linux VM, no Docker for Postgres) | **Cursor Cloud** |
+| Agent or dev on a **local machine** (laptop/desktop; use Docker Compose per readme) | **Local** |
+| Debugging a **GitHub Actions** failure | **Local** ports/commands above |
 
-### Environment Variables
+Do not use `test:e2e:agent` on a local Docker setup, or `test:e2e:db:start` in Cursor Cloud.
 
-The `.env` file uses `localhost:5432` (native PostgreSQL) instead of the Docker port `5435` documented in the README. The `.env.test` file also uses port `5432`.
+## Ports and databases
 
-### Starting the Dev Environment (full sequence)
+| Purpose | App URL | Cursor Cloud (native) | Local (Docker) |
+|--------|---------|----------------------|----------------|
+| Dev | `http://localhost:3000` | `agraria` @ `5432` | `agraria` @ `5435` |
+| Vitest | `http://localhost:3001` | `agraria_test` @ `5432` | `agraria` @ `5433` |
+| Playwright e2e | `http://127.0.0.1:3002` | `agraria_e2e` @ socket `5432` | `agraria` @ `5434` |
 
-```bash
-# 1. Start PostgreSQL
-sudo pg_ctlcluster 16 main start
+`.env` and `.env.test` are gitignored. **Cloud:** use `5432` URLs. **Local:** use `5435` / `5433` as in [readme.md](readme.md).
 
-# 2. Apply any new migrations
-npx prisma migrate dev
+## Before finishing a task
 
-# 3. Start the dev server
-npm run dev
-```
+- **API / lib / server logic:** `npm run test` (local: run `npm run test:db:start` first)
+- **UI, auth, parcels, treatments, dashboard charts:** e2e (commands below)
+- **Optional:** `npm run tsc`, `npm run precommit`
 
-The dev server runs on `http://localhost:3000`. Login at `/auth/signin` with the credentials from `.env` (see Authentication section below).
-
-### Common Commands
-
-Standard commands from `package.json`:
-- `npm run dev` — starts Next.js dev server on port 3000
-- `npm run lint` — ESLint
-- `npm run tsc` — TypeScript type checking
-- `npm run build` — production build (includes `prisma generate`)
-- `npm run seed` — seeds reference data (products, substances, diseases)
-- `npm run studio` — Prisma Studio GUI
-
-### Running Tests
-
-```bash
-npx vitest run
-```
-
-Tests use `.env.test` (loaded by vitest config). The global setup starts a Next.js server on port 3001 and connects to `agraria_test` database. No need to run `test:db:start` since PostgreSQL runs natively.
-
-One integration test (`should create a TODO treatment when all products used in last treatment are no longer considered active`) has a pre-existing date-sensitivity issue that may fail depending on the current month.
-
-### Running Playwright e2e Tests
-
-Use Playwright as the final agent check when UI flows, auth, parcel creation, treatment creation, or dashboard chart behavior changes.
+**E2e — Cursor Cloud:**
 
 ```bash
 npm run test:e2e:install
 npm run test:e2e:agent
 ```
 
-Agents should use native PostgreSQL via `npm run test:e2e:agent`; do not use Docker Compose in Cursor Cloud. The Playwright `beforeAll` resets the e2e database, seeds an authorized test user, one parcel, and four April treatments for the dashboard chart, then logs in through the credentials form. The reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
+**E2e — local (matches CI):** run `test:e2e:db:start` before `test:e2e` (same shell).
 
-When writing Playwright tests, prefer accessible selectors in this order: `getByRole` with a name, `getByLabel`, `getByPlaceholder`, and visible text. Avoid `getByTestId` unless there is no practical accessible surface; if a test needs one, first consider improving the component semantics with labels, roles, or accessible names.
+```bash
+npm run test:e2e:install
+npm run test:e2e:db:start
+npm run test:e2e
+npm run test:e2e:db:stop   # optional cleanup
+```
 
-### Pre-commit Hook
+Report which commands you ran and whether they passed.
 
-The `.husky/pre-commit` hook runs `npm run precommit` which executes:
-- `npm run lint` (ESLint)
-- `npx biome check .` (Biome formatting/linting)
+## Overview
 
-### Authentication (Dev/Test Credentials Login)
+Agricolala is a Next.js 16 + React 19 web app for managing vineyard treatments and tracking substance usage for organic EU compliance. Uses Prisma ORM with PostgreSQL, NextAuth, and is deployed on Vercel.
 
-A `CredentialsProvider` is enabled when `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` are set in `.env`. This allows agents and developers to log in without Google OAuth. The credentials provider works during both `npm run dev` and `npm run build` (since `next build` sets `NODE_ENV=production` internally).
+## Database
 
-**Required env vars for auth** (must be set in `.env`):
+Integration tests may set `session_replication_role`; the DB user needs superuser (or equivalent).
+
+**Cursor Cloud:** Native PostgreSQL **16** (no Docker — Docker Hub rate limits). Databases on `5432`: `agraria`, `agraria_test`, `agraria_e2e` (e2e DB created by `test:e2e:agent`). The `agraria` OS user should be a **superuser** (integration tests use `session_replication_role`).
+
+```bash
+sudo pg_ctlcluster 16 main start   # Linux; adjust on other OSes
+```
+
+**Local / CI:** Docker Postgres **15** images. Local: `docker compose up` (dev, `5435`). Vitest: `test:db:start` / `test:db:stop` (`5433`). E2e: `test:e2e:db:start` / `test:e2e:db:stop` (`5434`).
+
+## Environment variables
+
+- **Cloud:** `.env` / `.env.test` → `localhost:5432`
+- **Local:** `.env` / `.env.test` → `5435` / `5433` (see readme)
+- **E2e:** Playwright defaults in `playwright.config.ts`; Cloud overrides via `run-e2e-native.sh` (`agraria_e2e`)
+
+## Starting the dev environment
+
+**Cursor Cloud:**
+
+```bash
+sudo pg_ctlcluster 16 main start
+npx prisma migrate dev
+npm run dev
+```
+
+**Local:** `docker compose up`, then `npx prisma migrate dev`, `npm run seed`, `npm run dev` (readme).
+
+Dev app: `http://localhost:3000` → `/auth/signin`.
+
+## Common commands
+
+- `npm run dev`, `npm run test`, `npm run lint`, `npm run tsc`, `npm run build`, `npm run studio`, `npm run precommit`
+- `npm run seed` — reference data only; wipes products/substances/diseases on the DB in `.env` (dev), not test/e2e DBs
+- `test:db:start` / `test:db:stop` — **local** vitest Postgres
+- `test:e2e:install`, `test:e2e:agent` (**Cloud**), `test:e2e`, `test:e2e:db:start`, `test:e2e:db:stop` (**local** / CI)
+
+## Running tests
+
+```bash
+npm run test
+```
+
+Uses `.env.test` and `vitest.config.mts`. Global setup serves Next on **3001**.
+
+- **Cloud:** `agraria_test` on `5432`; no `test:db:start`
+- **Local:** `npm run test:db:start` before, `test:db:stop` after
+
+Flaky integration test (date-sensitive): `should create a TODO treatment when all products used in last treatment are no longer considered active (daysBetweenApplications reached)`.
+
+## Running Playwright e2e tests
+
+Final check for UI, auth, parcels, treatments, dashboard charts.
+
+**Shared:**
+
+- App on **`http://127.0.0.1:3002`**; dev on 3000 can stay up
+- E2e login: `playwright@agricolala.test` / `playwright-local-password` (not dev `.env` creds)
+- `beforeAll` resets e2e DB, seeds data, logs in, writes `e2e/.auth/user.json`
+- **Serial** suite; **English** UI (`/en`)
+- Reset guard (no override): **Cloud** — DB name contains **`e2e`** (`agraria_e2e` on `5432`); **Local / CI** — `localhost`/`127.0.0.1` port **5434** or host **`postgres-e2e`**
+
+**Cloud only:** `npm run test:e2e:agent` (`run-e2e-native.sh`; may need `sudo` on a fresh VM). Do not use Docker e2e in Cloud.
+
+**Local / CI:** run `test:e2e:db:start` (starts Postgres + migrations) **before** `npm run test:e2e` in the same shell session.
+
+On failure, inspect `test-results/` and `playwright-report/` (CI uploads these as artifacts).
+
+**Selectors:** `getByRole` (name) → `getByLabel` → `getByPlaceholder` → visible text. Avoid `getByTestId` unless accessibility cannot be improved.
+
+## Pre-commit hook
+
+`npm run precommit` → ESLint + `npx biome check .`
+
+## Authentication (credentials only)
+
+Agents must sign in with the **credentials** form only. Do not use or configure any other sign-in provider.
+
+When `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` are set and `VERCEL_ENV` is not `production`:
+
+**`.env` example:**
+
 ```
 TEST_USER_EMAIL=test@agricolala.dev
 TEST_USER_PASSWORD=test-password-dev
 NEXTAUTH_SECRET=dev-secret-key-for-local-development-only
 ```
 
-`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be left empty when `TEST_USER_EMAIL`/`TEST_USER_PASSWORD` are set — the app will start and build without the Google provider.
-
-**How login works:**
-
-1. Start the dev server: `npm run dev`
-2. Navigate to `http://localhost:3000/auth/signin`
-3. The sign-in page shows an email/password form (credentials provider)
-4. Enter `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` values and submit
-5. On first login, a `User` record is auto-created with `isAuthorized: true`
-6. After login you're redirected to the main app at `/{locale}`
-
-**First-time login note:** After the first credentials login, the app shows a Terms of Service dialog. Accept it to proceed to the full app UI.
-
-**Google OAuth:** When `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` are also set, Google OAuth appears as an additional sign-in option alongside credentials.
+1. `npm run dev` → `http://localhost:3000/auth/signin`
+2. “Sign in with credentials” with `.env` values
+3. First login creates authorized `User`; accept ToS if prompted (e2e seed sets `tosAcceptedAt` to skip ToS in Playwright)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,10 @@ Use Playwright as the final agent check when UI flows, auth, parcel creation, tr
 
 ```bash
 npm run test:e2e:install
-npm run test:e2e:db:start
-npm run test:e2e
-npm run test:e2e:db:stop
+npm run test:e2e:agent
 ```
 
-The e2e setup uses `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets that e2e database, seeds an authorized test user, one Cinque Terre parcel in Liguria, and four April treatments for the dashboard chart, then logs in through the credentials form. The reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
+Agents should use native PostgreSQL via `npm run test:e2e:agent`; do not use Docker Compose in Cursor Cloud. For local human runs, `npm run test:e2e:db:start`, `npm run test:e2e`, and `npm run test:e2e:db:stop` use `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets the e2e database, seeds an authorized test user, one parcel, and four April treatments for the dashboard chart, then logs in through the credentials form. The reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
 
 When writing Playwright tests, prefer accessible selectors in this order: `getByRole` with a name, `getByLabel`, `getByPlaceholder`, and visible text. Avoid `getByTestId` unless there is no practical accessible surface; if a test needs one, first consider improving the component semantics with labels, roles, or accessible names.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,19 @@ Tests use `.env.test` (loaded by vitest config). The global setup starts a Next.
 
 One integration test (`should create a TODO treatment when all products used in last treatment are no longer considered active`) has a pre-existing date-sensitivity issue that may fail depending on the current month.
 
+### Running Playwright e2e Tests
+
+Use Playwright as the final agent check when UI flows, auth, parcel creation, treatment creation, or dashboard chart behavior changes.
+
+```bash
+npm run test:e2e:install
+npm run test:e2e:db:start
+npm run test:e2e
+npm run test:e2e:db:stop
+```
+
+The e2e setup uses `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets that e2e database, seeds an authorized test user, one Cinque Terre parcel in Liguria, and four April treatments for the dashboard chart, then logs in through the credentials form. Do not point these tests at a development or production database unless you intentionally set `ALLOW_E2E_DB_RESET=true`.
+
 ### Pre-commit Hook
 
 The `.husky/pre-commit` hook runs `npm run precommit` which executes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ npm run test:e2e:db:stop
 
 The e2e setup uses `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets that e2e database, seeds an authorized test user, one Cinque Terre parcel in Liguria, and four April treatments for the dashboard chart, then logs in through the credentials form. Do not point these tests at a development or production database unless you intentionally set `ALLOW_E2E_DB_RESET=true`.
 
+When writing Playwright tests, prefer accessible selectors in this order: `getByRole` with a name, `getByLabel`, `getByPlaceholder`, and visible text. Avoid `getByTestId` unless there is no practical accessible surface; if a test needs one, first consider improving the component semantics with labels, roles, or accessible names.
+
 ### Pre-commit Hook
 
 The `.husky/pre-commit` hook runs `npm run precommit` which executes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ npm run test:e2e:install
 npm run test:e2e:agent
 ```
 
-Agents should use native PostgreSQL via `npm run test:e2e:agent`; do not use Docker Compose in Cursor Cloud. For local human runs, `npm run test:e2e:db:start`, `npm run test:e2e`, and `npm run test:e2e:db:stop` use `docker-compose.e2e.yml` on `localhost:5434`. The Playwright `beforeAll` resets the e2e database, seeds an authorized test user, one parcel, and four April treatments for the dashboard chart, then logs in through the credentials form. The reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
+Agents should use native PostgreSQL via `npm run test:e2e:agent`; do not use Docker Compose in Cursor Cloud. The Playwright `beforeAll` resets the e2e database, seeds an authorized test user, one parcel, and four April treatments for the dashboard chart, then logs in through the credentials form. The reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
 
 When writing Playwright tests, prefer accessible selectors in this order: `getByRole` with a name, `getByLabel`, `getByPlaceholder`, and visible text. Avoid `getByTestId` unless there is no practical accessible surface; if a test needs one, first consider improving the component semantics with labels, roles, or accessible names.
 

--- a/components/parcels/add-parcel-dialog.tsx
+++ b/components/parcels/add-parcel-dialog.tsx
@@ -62,7 +62,7 @@ export function AddParcelDialog({
 				...prev,
 				latitude: selectedLocation.lat.toString(),
 				longitude: selectedLocation.lng.toString(),
-				altitude: selectedLocation?.altitude?.toString(),
+				altitude: selectedLocation.altitude?.toString() ?? "",
 			}));
 		}
 	}, [selectedLocation]);

--- a/components/substances/chart-wrapper.tsx
+++ b/components/substances/chart-wrapper.tsx
@@ -28,6 +28,19 @@ interface ChartWrapperProps {
 	data: ChartData<"line">;
 	options: ChartOptions<"line">;
 	emptyMessage?: string;
+	testId?: string;
+}
+
+function getChartSummary(data: ChartData<"line">) {
+	return {
+		labels: data.labels?.map((label) => String(label)) ?? [],
+		datasets: data.datasets.map((dataset) => ({
+			label: String(dataset.label ?? ""),
+			data: dataset.data.map((value) =>
+				typeof value === "number" ? value : Number(value),
+			),
+		})),
+	};
 }
 
 export function ChartSkeleton() {
@@ -45,6 +58,7 @@ export function ChartWrapper({
 	data,
 	options,
 	emptyMessage,
+	testId,
 }: ChartWrapperProps) {
 	const hasData = data.datasets.some(
 		(dataset) =>
@@ -57,7 +71,11 @@ export function ChartWrapper({
 	}
 
 	return (
-		<div className="max-h-[400px] flex justify-center items-center">
+		<div
+			className="max-h-[400px] flex justify-center items-center"
+			data-chart-summary={JSON.stringify(getChartSummary(data))}
+			data-testid={testId}
+		>
 			<Line data={data} options={options} />
 		</div>
 	);

--- a/components/substances/chart-wrapper.tsx
+++ b/components/substances/chart-wrapper.tsx
@@ -13,6 +13,7 @@ import {
 import { Line } from "react-chartjs-2";
 import type { ChartData, ChartOptions } from "chart.js";
 import { Skeleton } from "../ui/skeleton";
+import { useId } from "react";
 
 ChartJS.register(
 	CategoryScale,
@@ -60,6 +61,7 @@ export function ChartWrapper({
 	emptyMessage,
 	ariaLabel,
 }: ChartWrapperProps) {
+	const captionId = useId();
 	const hasData = data.datasets.some(
 		(dataset) =>
 			Array.isArray(dataset.data) &&
@@ -71,13 +73,15 @@ export function ChartWrapper({
 	}
 
 	return (
-		<div
-			aria-label={ariaLabel}
+		<figure
+			aria-labelledby={captionId}
 			className="max-h-[400px] flex justify-center items-center"
 			data-chart-summary={JSON.stringify(getChartSummary(data))}
-			role="img"
 		>
+			<figcaption id={captionId} className="sr-only">
+				{ariaLabel}
+			</figcaption>
 			<Line data={data} options={options} />
-		</div>
+		</figure>
 	);
 }

--- a/components/substances/chart-wrapper.tsx
+++ b/components/substances/chart-wrapper.tsx
@@ -28,7 +28,7 @@ interface ChartWrapperProps {
 	data: ChartData<"line">;
 	options: ChartOptions<"line">;
 	emptyMessage?: string;
-	testId?: string;
+	ariaLabel: string;
 }
 
 function getChartSummary(data: ChartData<"line">) {
@@ -58,7 +58,7 @@ export function ChartWrapper({
 	data,
 	options,
 	emptyMessage,
-	testId,
+	ariaLabel,
 }: ChartWrapperProps) {
 	const hasData = data.datasets.some(
 		(dataset) =>
@@ -72,9 +72,10 @@ export function ChartWrapper({
 
 	return (
 		<div
+			aria-label={ariaLabel}
 			className="max-h-[400px] flex justify-center items-center"
 			data-chart-summary={JSON.stringify(getChartSummary(data))}
-			data-testid={testId}
+			role="img"
 		>
 			<Line data={data} options={options} />
 		</div>

--- a/components/substances/substance-chart.tsx
+++ b/components/substances/substance-chart.tsx
@@ -78,8 +78,8 @@ export function SubstanceChart({ data }: SubstanceChartProps) {
 		<ChartWrapper
 			data={chartData}
 			options={options}
+			ariaLabel={t("substances.monthlyPureActiveSubstanceKg")}
 			emptyMessage={t("substances.noTreatmentData")}
-			testId="substance-line-chart"
 		/>
 	);
 }

--- a/components/substances/substance-chart.tsx
+++ b/components/substances/substance-chart.tsx
@@ -79,6 +79,7 @@ export function SubstanceChart({ data }: SubstanceChartProps) {
 			data={chartData}
 			options={options}
 			emptyMessage={t("substances.noTreatmentData")}
+			testId="substance-line-chart"
 		/>
 	);
 }

--- a/components/substances/substance-yearly-chart.tsx
+++ b/components/substances/substance-yearly-chart.tsx
@@ -124,6 +124,7 @@ export function SubstanceYearlyChart({
 		<ChartWrapper
 			data={chartData}
 			options={options}
+			ariaLabel={t("substances.yearlyUsageTitle")}
 			emptyMessage={t("substances.noTreatmentData")}
 		/>
 	);

--- a/components/treatments/add-treatment-button.tsx
+++ b/components/treatments/add-treatment-button.tsx
@@ -27,6 +27,7 @@ export const AddTreatmentButton = ({
 	return (
 		<>
 			<Button
+				aria-label="Add treatment"
 				onClick={() => setIsAddTreatmentOpen(true)}
 				style={{ bottom: 100 }}
 				className="z-10 fixed right-6 h-16 w-16 rounded-full shadow-lg bg-main-gradient hover:bg-primary-700"

--- a/components/treatments/add-treatment-button.tsx
+++ b/components/treatments/add-treatment-button.tsx
@@ -11,6 +11,7 @@ import {
 	useCompositions,
 } from "@/contexts/cached-data-context";
 import { type ParcelWithTreatments } from "@/lib/data-fetcher";
+import { useTranslations } from "@/contexts/translations-context";
 
 export const AddTreatmentButton = ({
 	parcelId,
@@ -24,10 +25,11 @@ export const AddTreatmentButton = ({
 	const products = useProducts();
 	const substances = useSubstances();
 	const compositions = useCompositions();
+	const { t } = useTranslations();
 	return (
 		<>
 			<Button
-				aria-label="Add treatment"
+				aria-label={t("treatments.addTreatment")}
 				onClick={() => setIsAddTreatmentOpen(true)}
 				style={{ bottom: 100 }}
 				className="z-10 fixed right-6 h-16 w-16 rounded-full shadow-lg bg-main-gradient hover:bg-primary-700"

--- a/contexts/translations-context.tsx
+++ b/contexts/translations-context.tsx
@@ -94,6 +94,10 @@ export function useTranslations() {
 }
 
 export const getLocaleFromBrowser = (): Locale => {
+	// SSR has no navigator; sign-in renders null until the client session check, so the real UI uses the browser locale.
+	if (typeof navigator === "undefined") {
+		return defaultLocale;
+	}
 	const browserLang =
 		navigator.language ||
 		navigator.languages?.find((lang) => lang in appLanguages);

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,30 @@
+services:
+  postgres-e2e:
+    image: postgres:15-alpine
+    command:
+      [
+        "postgres",
+        "-c",
+        "fsync=off",
+        "-c",
+        "synchronous_commit=off",
+        "-c",
+        "full_page_writes=off",
+      ]
+    ports:
+      - "127.0.0.1:5434:5432"
+    environment:
+      POSTGRES_USER: agraria
+      POSTGRES_PASSWORD: agraria
+      POSTGRES_DB: agraria
+    volumes:
+      - postgres_e2e_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agraria -d agraria"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_e2e_data:
+    driver: local

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import {
+	authStatePath,
+	cinqueTerreParcel,
+	disconnectE2ePrisma,
+	e2eUser,
+	ensureAuthStateDirectory,
+	expectedCopperChartKg,
+	seedE2eData,
+} from "./support/e2e-data";
+
+interface ChartDatasetSummary {
+	label: string;
+	data: number[];
+}
+
+interface ChartSummary {
+	labels: string[];
+	datasets: ChartDatasetSummary[];
+}
+
+const visibleErrorText =
+	/failed|invalid credentials|access denied|application error|internal server error|is required|must be/i;
+
+test.describe.configure({ mode: "serial" });
+test.use({ storageState: authStatePath });
+
+test.beforeAll(async ({ browser }) => {
+	await seedE2eData();
+	await ensureAuthStateDirectory();
+
+	const page = await browser.newPage();
+	await page.goto("/auth/signin");
+	await page.getByPlaceholder("Email").fill(e2eUser.email);
+	await page.getByPlaceholder("Password").fill(e2eUser.password);
+	await page.getByRole("button", { name: "Sign in with credentials" }).click();
+	await page.waitForURL(/\/en(?:$|[/?#])/);
+	await expect(page.getByRole("heading", { name: /Welcome/i })).toBeVisible();
+	await expectNoVisibleErrors(page);
+	await page.context().storageState({ path: authStatePath });
+	await page.close();
+});
+
+test.afterAll(async () => {
+	await disconnectE2ePrisma();
+});
+
+test("dashboard shows April treatment data in the line chart", async ({
+	page,
+}) => {
+	await page.goto("/en");
+	await expect(page.getByRole("heading", { name: /Welcome/i })).toBeVisible();
+	await expectNoVisibleErrors(page);
+
+	const chart = page.getByTestId("substance-line-chart");
+	await expect(chart).toBeVisible();
+
+	const summary = await getChartSummary(chart);
+	expect(summary.labels).toEqual([
+		"Jan",
+		"Feb",
+		"Mar",
+		"Apr",
+		"May",
+		"Jun",
+		"Jul",
+		"Aug",
+		"Sep",
+		"Oct",
+		"Nov",
+		"Dec",
+	]);
+
+	const copperDataset = summary.datasets.find(
+		(dataset) => dataset.label === "Copper",
+	);
+	expect(copperDataset?.data).toEqual([...expectedCopperChartKg]);
+	await expect(page.getByText("4000.00 gr of product")).toBeVisible();
+	await expect(
+		page.getByText("1000 gr of pure active substance"),
+	).toBeVisible();
+	await expect(
+		page.getByText("1 kg/ha of pure active substance"),
+	).toBeVisible();
+	await expectNoVisibleErrors(page);
+});
+
+test("adds a parcel without visible errors", async ({ page }) => {
+	await page.goto("/en/parcels");
+	await expect(page.getByRole("heading", { name: "Parcels" })).toBeVisible();
+	await expectNoVisibleErrors(page);
+
+	await page
+		.locator(".leaflet-container")
+		.click({ position: { x: 220, y: 180 } });
+
+	const dialog = page.getByRole("dialog", { name: "Add New Parcel" });
+	await expect(dialog).toBeVisible();
+	await dialog.getByLabel("Parcel Name").fill("E2E Added Parcel");
+	await dialog.getByLabel("Width (meters)").fill("80");
+	await dialog.getByLabel("Height (meters)").fill("45");
+	await dialog.getByLabel("Latitude").fill("44.135");
+	await dialog.getByLabel("Longitude").fill("9.684");
+	await dialog.getByLabel("Altitude").fill("65");
+	await expectNoVisibleErrors(page);
+
+	await dialog.getByRole("button", { name: "Add Parcel" }).click();
+	await expect(dialog).toBeHidden();
+	await expect(
+		page.getByRole("heading", { name: "E2E Added Parcel" }),
+	).toBeVisible();
+	await expectNoVisibleErrors(page);
+});
+
+test("adds a treatment without visible errors", async ({ page }) => {
+	await page.goto("/en/treatments");
+	await expect(page.getByRole("heading", { name: "Treatments" })).toBeVisible();
+	await expectNoVisibleErrors(page);
+
+	await page.getByRole("button", { name: "Add treatment" }).click();
+
+	const dialog = page.getByRole("dialog", { name: "Add Treatment" });
+	await expect(dialog).toBeVisible();
+	await dialog.getByText("Select parcel").click();
+	await page
+		.getByRole("option", {
+			name: new RegExp(cinqueTerreParcel.name),
+		})
+		.click();
+	await dialog.getByText("Select disease").click();
+	await page.getByRole("option", { name: "Peronospora" }).click();
+	await dialog.getByText("Select product").click();
+	await page.getByRole("option", { name: "Pasta cafaro" }).click();
+	await dialog.getByPlaceholder("gr").fill("50");
+	await expectNoVisibleErrors(page);
+
+	await dialog.getByRole("button", { name: "Create Treatment" }).click();
+	await expect(dialog).toBeHidden();
+	await expect(
+		page.getByRole("heading", { name: "5 Completed" }),
+	).toBeVisible();
+	await expectNoVisibleErrors(page);
+});
+
+async function expectNoVisibleErrors(page: Page) {
+	await expect(page.getByText(visibleErrorText)).toHaveCount(0);
+	await expect(page.locator("[data-nextjs-dialog-overlay]")).toHaveCount(0);
+}
+
+async function getChartSummary(chart: Locator) {
+	const chartSummary = await chart.getAttribute("data-chart-summary");
+	expect(chartSummary).not.toBeNull();
+	return JSON.parse(chartSummary ?? "{}") as ChartSummary;
+}

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import {
 	authStatePath,
-	cinqueTerreParcel,
 	disconnectE2ePrisma,
 	e2eUser,
 	ensureAuthStateDirectory,
 	expectedCopperChartKg,
+	seededParcel,
 	seedE2eData,
 } from "./support/e2e-data";
 
@@ -130,7 +130,7 @@ test("adds a treatment without visible errors", async ({ page }) => {
 	await dialog.getByText("Select parcel").click();
 	await page
 		.getByRole("option", {
-			name: new RegExp(cinqueTerreParcel.name),
+			name: new RegExp(seededParcel.name),
 		})
 		.click();
 	await dialog.getByText("Select disease").click();

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -125,7 +125,7 @@ test("adds a treatment without visible errors", async ({ page }) => {
 	await expect(page.getByRole("heading", { name: "Treatments" })).toBeVisible();
 	await expectNoVisibleErrors(page);
 
-	await page.getByRole("button", { name: "Add treatment" }).click();
+	await page.getByRole("button", { name: "Add Treatment" }).click();
 
 	const dialog = page.getByRole("dialog", { name: "Add Treatment" });
 	await expect(dialog).toBeVisible();

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -81,12 +81,10 @@ test("dashboard shows April treatment data in the line chart", async ({
 		(dataset) => dataset.label === "Copper",
 	);
 	expect(copperDataset?.data).toEqual([...expectedCopperChartKg]);
-	await expect(main.getByText("4000.00 gr of product")).toBeVisible();
+	await expect(main.getByText("320.00 gr of product")).toBeVisible();
+	await expect(main.getByText("80 gr of pure active substance")).toBeVisible();
 	await expect(
-		main.getByText("1000 gr of pure active substance"),
-	).toBeVisible();
-	await expect(
-		main.getByText("1 kg/ha of pure active substance"),
+		main.getByText("2 kg/ha of pure active substance"),
 	).toBeVisible();
 	await expectNoVisibleErrors(page);
 });

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -56,7 +56,9 @@ test("dashboard shows April treatment data in the line chart", async ({
 	await expectNoVisibleErrors(page);
 
 	const main = page.getByRole("main");
-	const chart = main.getByTestId("substance-line-chart");
+	const chart = main.getByRole("img", {
+		name: "Monthly pure active substance (kg)",
+	});
 	await expect(chart).toBeVisible();
 
 	const summary = await getChartSummary(chart);

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -81,8 +81,8 @@ test("dashboard shows April treatment data in the line chart", async ({
 		(dataset) => dataset.label === "Copper",
 	);
 	expect(copperDataset?.data).toEqual([...expectedCopperChartKg]);
-	await expect(main.getByText("320.00 gr of product")).toBeVisible();
-	await expect(main.getByText("80 gr of pure active substance")).toBeVisible();
+	await expect(main.getByText("256.00 gr of product")).toBeVisible();
+	await expect(main.getByText("64 gr of pure active substance")).toBeVisible();
 	await expect(
 		main.getByText("2 kg/ha of pure active substance"),
 	).toBeVisible();

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -29,7 +29,10 @@ test.beforeAll(async ({ browser }) => {
 	await seedE2eData();
 	await ensureAuthStateDirectory();
 
-	const page = await browser.newPage();
+	const context = await browser.newContext({
+		storageState: { cookies: [], origins: [] },
+	});
+	const page = await context.newPage();
 	await page.goto("/auth/signin");
 	await page.getByPlaceholder("Email").fill(e2eUser.email);
 	await page.getByPlaceholder("Password").fill(e2eUser.password);
@@ -37,8 +40,8 @@ test.beforeAll(async ({ browser }) => {
 	await page.waitForURL(/\/en(?:$|[/?#])/);
 	await expect(page.getByRole("heading", { name: /Welcome/i })).toBeVisible();
 	await expectNoVisibleErrors(page);
-	await page.context().storageState({ path: authStatePath });
-	await page.close();
+	await context.storageState({ path: authStatePath });
+	await context.close();
 });
 
 test.afterAll(async () => {
@@ -52,7 +55,8 @@ test("dashboard shows April treatment data in the line chart", async ({
 	await expect(page.getByRole("heading", { name: /Welcome/i })).toBeVisible();
 	await expectNoVisibleErrors(page);
 
-	const chart = page.getByTestId("substance-line-chart");
+	const main = page.getByRole("main");
+	const chart = main.getByTestId("substance-line-chart");
 	await expect(chart).toBeVisible();
 
 	const summary = await getChartSummary(chart);
@@ -75,12 +79,12 @@ test("dashboard shows April treatment data in the line chart", async ({
 		(dataset) => dataset.label === "Copper",
 	);
 	expect(copperDataset?.data).toEqual([...expectedCopperChartKg]);
-	await expect(page.getByText("4000.00 gr of product")).toBeVisible();
+	await expect(main.getByText("4000.00 gr of product")).toBeVisible();
 	await expect(
-		page.getByText("1000 gr of pure active substance"),
+		main.getByText("1000 gr of pure active substance"),
 	).toBeVisible();
 	await expect(
-		page.getByText("1 kg/ha of pure active substance"),
+		main.getByText("1 kg/ha of pure active substance"),
 	).toBeVisible();
 	await expectNoVisibleErrors(page);
 });
@@ -91,7 +95,9 @@ test("adds a parcel without visible errors", async ({ page }) => {
 	await expectNoVisibleErrors(page);
 
 	await page
+		.getByRole("main")
 		.locator(".leaflet-container")
+		.last()
 		.click({ position: { x: 220, y: 180 } });
 
 	const dialog = page.getByRole("dialog", { name: "Add New Parcel" });

--- a/e2e/agricolala.spec.ts
+++ b/e2e/agricolala.spec.ts
@@ -56,7 +56,7 @@ test("dashboard shows April treatment data in the line chart", async ({
 	await expectNoVisibleErrors(page);
 
 	const main = page.getByRole("main");
-	const chart = main.getByRole("img", {
+	const chart = main.getByRole("figure", {
 		name: "Monthly pure active substance (kg)",
 	});
 	await expect(chart).toBeVisible();

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -22,6 +22,8 @@ export const cinqueTerreParcel = {
 } as const;
 
 const APRIL_TREATMENT_DAYS = [2, 9, 16, 23] as const;
+// 4 x 80g product at 25% copper on 400m2 = 80g copper, or 2kg/ha.
+// This stays below the 4kg/ha annual copper cap while still giving the chart data.
 const COPPER_PRODUCT_DOSE_GRAMS = 80;
 const COPPER_PRODUCT_COPPER_FRACTION = 0.25;
 const totalCopperProductDoseGrams =

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -30,14 +30,42 @@ export async function ensureAuthStateDirectory() {
 
 function assertSafeE2eDatabase() {
 	const databaseUrl = process.env.DATABASE_URL ?? "";
-	const isDefaultE2eDatabase =
-		databaseUrl.includes("localhost:5434") ||
-		databaseUrl.includes("127.0.0.1:5434");
+	const { databaseName, hostname, isSafe } =
+		parseE2eDatabaseSafety(databaseUrl);
 
-	if (!isDefaultE2eDatabase && process.env.ALLOW_E2E_DB_RESET !== "true") {
+	if (!isSafe) {
 		throw new Error(
-			"Refusing to reset a non-e2e database. Use the Docker e2e database on port 5434 or set ALLOW_E2E_DB_RESET=true.",
+			`Refusing to reset database host "${hostname}" and database "${databaseName}". Playwright e2e resets are limited to localhost/127.0.0.1 on port 5434, local database names containing "e2e", or the "postgres-e2e" Docker host.`,
 		);
+	}
+}
+
+function parseE2eDatabaseSafety(databaseUrl: string) {
+	try {
+		const url = new URL(databaseUrl);
+		const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+		const databaseName = decodeURIComponent(url.pathname.replace(/^\//, ""));
+		const protocol = url.protocol.replace(":", "");
+		const localHosts = new Set(["localhost", "127.0.0.1", "::1"]);
+		const dockerE2eHosts = new Set(["postgres-e2e"]);
+		const isPostgres = protocol === "postgresql" || protocol === "postgres";
+		const isLocalE2ePort = localHosts.has(hostname) && url.port === "5434";
+		const isLocalE2eDatabase =
+			localHosts.has(hostname) && databaseName.toLowerCase().includes("e2e");
+		const isDockerE2eHost = dockerE2eHosts.has(hostname);
+
+		return {
+			databaseName,
+			hostname,
+			isSafe:
+				isPostgres && (isLocalE2ePort || isLocalE2eDatabase || isDockerE2eHost),
+		};
+	} catch {
+		return {
+			databaseName: "unknown",
+			hostname: "invalid-url",
+			isSafe: false,
+		};
 	}
 }
 

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -22,17 +22,23 @@ export const cinqueTerreParcel = {
 } as const;
 
 const APRIL_TREATMENT_DAYS = [2, 9, 16, 23] as const;
-// 4 x 80g product at 25% copper on 400m2 = 80g copper, or 2kg/ha.
-// This stays below the 4kg/ha annual copper cap while still giving the chart data.
-const COPPER_PRODUCT_DOSE_GRAMS = 80;
 const COPPER_PRODUCT_COPPER_FRACTION = 0.25;
+const TYPICAL_SEASON_TREATMENT_COUNT = 10;
+const MAX_COPPER_KG_PER_HA = 4;
+const PARCEL_AREA_M2 = cinqueTerreParcel.width * cinqueTerreParcel.height;
+const maxCopperGramsPerSeason =
+	(MAX_COPPER_KG_PER_HA * 1_000 * PARCEL_AREA_M2) / 10_000;
+// 10 x 64g product at 25% copper on 400m2 = 160g copper/year, or 4kg/ha.
+// This fixture seeds only 4 April treatments, so the dashboard starts at 1.6kg/ha.
+const COPPER_PRODUCT_DOSE_GRAMS =
+	maxCopperGramsPerSeason /
+	TYPICAL_SEASON_TREATMENT_COUNT /
+	COPPER_PRODUCT_COPPER_FRACTION;
 const totalCopperProductDoseGrams =
 	APRIL_TREATMENT_DAYS.length * COPPER_PRODUCT_DOSE_GRAMS;
 const totalCopperGrams =
 	totalCopperProductDoseGrams * COPPER_PRODUCT_COPPER_FRACTION;
-const totalCopperPerHaGrams =
-	(totalCopperGrams * 10_000) /
-	(cinqueTerreParcel.width * cinqueTerreParcel.height);
+const totalCopperPerHaGrams = (totalCopperGrams * 10_000) / PARCEL_AREA_M2;
 
 export const expectedCopperChartKg = [
 	0,

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -1,0 +1,196 @@
+import { PrismaClient, CultureType, TreatmentStatus } from "@prisma/client";
+import { dirname, join } from "node:path";
+import { mkdir } from "node:fs/promises";
+
+const prisma = new PrismaClient();
+
+export const authStatePath = join(process.cwd(), "e2e", ".auth", "user.json");
+
+export const e2eUser = {
+	email: process.env.TEST_USER_EMAIL ?? "playwright@agricolala.test",
+	password: process.env.TEST_USER_PASSWORD ?? "playwright-local-password",
+} as const;
+
+export const cinqueTerreParcel = {
+	name: "Cinque Terre Vineyard",
+	latitude: 44.1461,
+	longitude: 9.6543,
+	altitude: 120,
+	width: 100,
+	height: 100,
+} as const;
+
+export const expectedCopperChartKg = [
+	0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+] as const;
+
+export async function ensureAuthStateDirectory() {
+	await mkdir(dirname(authStatePath), { recursive: true });
+}
+
+function assertSafeE2eDatabase() {
+	const databaseUrl = process.env.DATABASE_URL ?? "";
+	const isDefaultE2eDatabase =
+		databaseUrl.includes("localhost:5434") ||
+		databaseUrl.includes("127.0.0.1:5434");
+
+	if (!isDefaultE2eDatabase && process.env.ALLOW_E2E_DB_RESET !== "true") {
+		throw new Error(
+			"Refusing to reset a non-e2e database. Use the Docker e2e database on port 5434 or set ALLOW_E2E_DB_RESET=true.",
+		);
+	}
+}
+
+export async function seedE2eData() {
+	assertSafeE2eDatabase();
+
+	const year = new Date().getFullYear();
+	const monthlyCopperGrams = [0, 0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, 0] as const;
+
+	await prisma.$transaction(async (tx) => {
+		await tx.productApplication.deleteMany();
+		await tx.treatment.deleteMany();
+		await tx.parcelSubstanceAggregation.deleteMany();
+		await tx.userSubstanceAggregation.deleteMany();
+		await tx.parcel.deleteMany();
+		await tx.session.deleteMany();
+		await tx.account.deleteMany();
+		await tx.user.deleteMany();
+		await tx.substanceDose.deleteMany();
+		await tx.product.deleteMany();
+		await tx.disease.deleteMany();
+		await tx.substance.deleteMany();
+
+		const user = await tx.user.create({
+			data: {
+				email: e2eUser.email,
+				emailVerified: new Date(),
+				isAuthorized: true,
+				locale: "en",
+				name: "Playwright User",
+				tosAcceptedAt: new Date(),
+			},
+		});
+
+		const peronospora = await tx.disease.create({
+			data: {
+				name: "Peronospora",
+				description: "Downy mildew, a fungal disease affecting grapevines",
+				sensitivityMonthMin: 3,
+				sensitivityMonthMax: 7,
+			},
+		});
+
+		const oidium = await tx.disease.create({
+			data: {
+				name: "Oidium",
+				description: "Powdery mildew, a fungal disease affecting grapevines",
+				sensitivityMonthMin: 4,
+				sensitivityMonthMax: 8,
+			},
+		});
+
+		const copper = await tx.substance.create({
+			data: {
+				name: "Copper",
+				maxDosage: 4,
+				diseases: {
+					connect: [{ id: peronospora.id }],
+				},
+			},
+		});
+
+		const sulfur = await tx.substance.create({
+			data: {
+				name: "Sulfur",
+				maxDosage: 10,
+				diseases: {
+					connect: [{ id: oidium.id }],
+				},
+			},
+		});
+
+		const copperProduct = await tx.product.create({
+			data: {
+				name: "Pasta cafaro",
+				brand: "Pasta cafaro",
+				maxApplications: 6,
+				composition: {
+					create: [{ substanceId: copper.id, dose: 25 }],
+				},
+			},
+		});
+
+		await tx.product.create({
+			data: {
+				name: "Zolfo tiovit",
+				brand: "Zolfo tiovit",
+				maxApplications: 10,
+				composition: {
+					create: [{ substanceId: sulfur.id, dose: 80 }],
+				},
+			},
+		});
+
+		const parcel = await tx.parcel.create({
+			data: {
+				...cinqueTerreParcel,
+				type: CultureType.VINEYARD,
+				userId: user.id,
+			},
+		});
+
+		for (const day of [2, 9, 16, 23]) {
+			const treatment = await tx.treatment.create({
+				data: {
+					appliedDate: new Date(Date.UTC(year, 3, day, 12)),
+					diseaseIds: [peronospora.id],
+					parcelId: parcel.id,
+					status: TreatmentStatus.DONE,
+					userId: user.id,
+					waterDose: 10,
+				},
+			});
+
+			await tx.productApplication.create({
+				data: {
+					dose: 1000,
+					productId: copperProduct.id,
+					treatmentId: treatment.id,
+				},
+			});
+		}
+
+		await tx.userSubstanceAggregation.create({
+			data: {
+				applicationCount: 4,
+				monthlyData: [...monthlyCopperGrams],
+				substanceId: copper.id,
+				substanceName: copper.name,
+				totalDoseOfProduct: 4000,
+				totalUsedOfPureActiveSubstance: 1000,
+				totalUsedOfPureActiveSubstancePerHa: 1000,
+				userId: user.id,
+				year,
+			},
+		});
+
+		await tx.parcelSubstanceAggregation.create({
+			data: {
+				applicationCount: 4,
+				monthlyData: [...monthlyCopperGrams],
+				parcelId: parcel.id,
+				substanceId: copper.id,
+				substanceName: copper.name,
+				totalDoseOfProduct: 4000,
+				totalUsedOfPureActiveSubstance: 1000,
+				totalUsedOfPureActiveSubstancePerHa: 1000,
+				year,
+			},
+		});
+	});
+}
+
+export async function disconnectE2ePrisma() {
+	await prisma.$disconnect();
+}

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -17,12 +17,34 @@ export const cinqueTerreParcel = {
 	latitude: 44.1461,
 	longitude: 9.6543,
 	altitude: 120,
-	width: 100,
-	height: 100,
+	width: 20,
+	height: 20,
 } as const;
 
+const APRIL_TREATMENT_DAYS = [2, 9, 16, 23] as const;
+const COPPER_PRODUCT_DOSE_GRAMS = 80;
+const COPPER_PRODUCT_COPPER_FRACTION = 0.25;
+const totalCopperProductDoseGrams =
+	APRIL_TREATMENT_DAYS.length * COPPER_PRODUCT_DOSE_GRAMS;
+const totalCopperGrams =
+	totalCopperProductDoseGrams * COPPER_PRODUCT_COPPER_FRACTION;
+const totalCopperPerHaGrams =
+	(totalCopperGrams * 10_000) /
+	(cinqueTerreParcel.width * cinqueTerreParcel.height);
+
 export const expectedCopperChartKg = [
-	0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+	0,
+	0,
+	0,
+	totalCopperGrams / 1_000,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
 ] as const;
 
 export async function ensureAuthStateDirectory() {
@@ -74,7 +96,20 @@ export async function seedE2eData() {
 	assertSafeE2eDatabase();
 
 	const year = new Date().getFullYear();
-	const monthlyCopperGrams = [0, 0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, 0] as const;
+	const monthlyCopperGrams = [
+		0,
+		0,
+		0,
+		totalCopperGrams,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	] as const;
 
 	await prisma.$transaction(async (tx) => {
 		await tx.productApplication.deleteMany();
@@ -111,7 +146,7 @@ export async function seedE2eData() {
 			},
 		});
 
-		for (const day of [2, 9, 16, 23]) {
+		for (const day of APRIL_TREATMENT_DAYS) {
 			const treatment = await tx.treatment.create({
 				data: {
 					appliedDate: new Date(Date.UTC(year, 3, day, 12)),
@@ -125,7 +160,7 @@ export async function seedE2eData() {
 
 			await tx.productApplication.create({
 				data: {
-					dose: 1000,
+					dose: COPPER_PRODUCT_DOSE_GRAMS,
 					productId: copperProduct.id,
 					treatmentId: treatment.id,
 				},
@@ -138,9 +173,9 @@ export async function seedE2eData() {
 				monthlyData: [...monthlyCopperGrams],
 				substanceId: copper.id,
 				substanceName: copper.name,
-				totalDoseOfProduct: 4000,
-				totalUsedOfPureActiveSubstance: 1000,
-				totalUsedOfPureActiveSubstancePerHa: 1000,
+				totalDoseOfProduct: totalCopperProductDoseGrams,
+				totalUsedOfPureActiveSubstance: totalCopperGrams,
+				totalUsedOfPureActiveSubstancePerHa: totalCopperPerHaGrams,
 				userId: user.id,
 				year,
 			},
@@ -153,9 +188,9 @@ export async function seedE2eData() {
 				parcelId: parcel.id,
 				substanceId: copper.id,
 				substanceName: copper.name,
-				totalDoseOfProduct: 4000,
-				totalUsedOfPureActiveSubstance: 1000,
-				totalUsedOfPureActiveSubstancePerHa: 1000,
+				totalDoseOfProduct: totalCopperProductDoseGrams,
+				totalUsedOfPureActiveSubstance: totalCopperGrams,
+				totalUsedOfPureActiveSubstancePerHa: totalCopperPerHaGrams,
 				year,
 			},
 		});

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -12,8 +12,8 @@ export const e2eUser = {
 	password: process.env.TEST_USER_PASSWORD ?? "playwright-local-password",
 } as const;
 
-export const cinqueTerreParcel = {
-	name: "Cinque Terre Vineyard",
+export const seededParcel = {
+	name: "E2E Vineyard",
 	latitude: 44.1461,
 	longitude: 9.6543,
 	altitude: 120,
@@ -25,7 +25,7 @@ const APRIL_TREATMENT_DAYS = [2, 9, 16, 23] as const;
 const COPPER_PRODUCT_COPPER_FRACTION = 0.25;
 const TYPICAL_SEASON_TREATMENT_COUNT = 10;
 const MAX_COPPER_KG_PER_HA = 4;
-const PARCEL_AREA_M2 = cinqueTerreParcel.width * cinqueTerreParcel.height;
+const PARCEL_AREA_M2 = seededParcel.width * seededParcel.height;
 const maxCopperGramsPerSeason =
 	(MAX_COPPER_KG_PER_HA * 1_000 * PARCEL_AREA_M2) / 10_000;
 // 10 x 64g product at 25% copper on 400m2 = 160g copper/year, or 4kg/ha.
@@ -148,7 +148,7 @@ export async function seedE2eData() {
 
 		const parcel = await tx.parcel.create({
 			data: {
-				...cinqueTerreParcel,
+				...seededParcel,
 				type: CultureType.VINEYARD,
 				userId: user.id,
 			},

--- a/e2e/support/e2e-data.ts
+++ b/e2e/support/e2e-data.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, CultureType, TreatmentStatus } from "@prisma/client";
 import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
+import { seedReferenceData } from "../../prisma/seed";
 
 const prisma = new PrismaClient();
 
@@ -100,65 +101,7 @@ export async function seedE2eData() {
 			},
 		});
 
-		const peronospora = await tx.disease.create({
-			data: {
-				name: "Peronospora",
-				description: "Downy mildew, a fungal disease affecting grapevines",
-				sensitivityMonthMin: 3,
-				sensitivityMonthMax: 7,
-			},
-		});
-
-		const oidium = await tx.disease.create({
-			data: {
-				name: "Oidium",
-				description: "Powdery mildew, a fungal disease affecting grapevines",
-				sensitivityMonthMin: 4,
-				sensitivityMonthMax: 8,
-			},
-		});
-
-		const copper = await tx.substance.create({
-			data: {
-				name: "Copper",
-				maxDosage: 4,
-				diseases: {
-					connect: [{ id: peronospora.id }],
-				},
-			},
-		});
-
-		const sulfur = await tx.substance.create({
-			data: {
-				name: "Sulfur",
-				maxDosage: 10,
-				diseases: {
-					connect: [{ id: oidium.id }],
-				},
-			},
-		});
-
-		const copperProduct = await tx.product.create({
-			data: {
-				name: "Pasta cafaro",
-				brand: "Pasta cafaro",
-				maxApplications: 6,
-				composition: {
-					create: [{ substanceId: copper.id, dose: 25 }],
-				},
-			},
-		});
-
-		await tx.product.create({
-			data: {
-				name: "Zolfo tiovit",
-				brand: "Zolfo tiovit",
-				maxApplications: 10,
-				composition: {
-					create: [{ substanceId: sulfur.id, dose: 80 }],
-				},
-			},
-		});
+		const { copper, copperProduct, peronospora } = await seedReferenceData(tx);
 
 		const parcel = await tx.parcel.create({
 			data: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.0.0",
 				"@dotenvx/dotenvx": "^1.48.3",
+				"@playwright/test": "^1.60.0",
 				"@tailwindcss/postcss": "^4.1.11",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/react": "^16.3.0",
@@ -2427,6 +2428,22 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@prisma/client": {
@@ -9792,6 +9809,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
 		"test": "vitest run",
 		"test:db:start": "scripts/run-test-integration.sh",
 		"test:db:stop": "docker-compose -f docker-compose.test.yml down",
+		"test:e2e": "playwright test",
+		"test:e2e:db:start": "scripts/setup-e2e-db.sh",
+		"test:e2e:db:stop": "docker compose -f docker-compose.e2e.yml down",
+		"test:e2e:install": "playwright install chromium",
 		"prettify": "npx @biomejs/biome format --write --fix .",
 		"create-admin-user": "npx tsx scripts/create-admin-user.ts",
 		"prepare": "husky",
@@ -79,6 +83,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.0.0",
 		"@dotenvx/dotenvx": "^1.48.3",
+		"@playwright/test": "^1.60.0",
 		"@tailwindcss/postcss": "^4.1.11",
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test:db:start": "scripts/run-test-integration.sh",
 		"test:db:stop": "docker-compose -f docker-compose.test.yml down",
 		"test:e2e": "playwright test",
+		"test:e2e:agent": "scripts/run-e2e-native.sh",
 		"test:e2e:db:start": "scripts/setup-e2e-db.sh",
 		"test:e2e:db:stop": "docker compose -f docker-compose.e2e.yml down",
 		"test:e2e:install": "playwright install chromium",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3002";
+const serverUrl = new URL(baseURL);
+const port = serverUrl.port || "3002";
+
+process.env.DATABASE_URL ??=
+	"postgresql://agraria:agraria@localhost:5434/agraria?schema=public";
+process.env.DIRECT_URL ??= process.env.DATABASE_URL;
+process.env.NEXTAUTH_SECRET ??= "playwright-local-secret";
+process.env.NEXTAUTH_URL ??= baseURL;
+process.env.TEST_USER_EMAIL ??= "playwright@agricolala.test";
+process.env.TEST_USER_PASSWORD ??= "playwright-local-password";
+
+export default defineConfig({
+	testDir: "./e2e",
+	fullyParallel: false,
+	timeout: 45_000,
+	expect: {
+		timeout: 10_000,
+	},
+	use: {
+		baseURL,
+		trace: "retain-on-failure",
+		screenshot: "only-on-failure",
+	},
+	webServer: {
+		command: `npm run dev -- --hostname ${serverUrl.hostname} --port ${port}`,
+		url: `${baseURL}/api/health`,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+});

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,19 +1,23 @@
 import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
+interface ReferenceDataClient {
+	disease: PrismaClient["disease"];
+	product: PrismaClient["product"];
+	productApplication: PrismaClient["productApplication"];
+	substance: PrismaClient["substance"];
+	substanceDose: PrismaClient["substanceDose"];
+}
 
-async function main() {
-	// Delete existing data
-	console.log("Deleting existing data...");
-	await prisma.substanceDose.deleteMany();
-	await prisma.productApplication.deleteMany();
-	await prisma.substance.deleteMany();
-	await prisma.disease.deleteMany();
-	await prisma.product.deleteMany();
-	console.log("Existing data deleted.");
+export async function cleanReferenceData(db: ReferenceDataClient) {
+	await db.substanceDose.deleteMany();
+	await db.productApplication.deleteMany();
+	await db.substance.deleteMany();
+	await db.disease.deleteMany();
+	await db.product.deleteMany();
+}
 
-	// Create diseases
-	const oidium = await prisma.disease.create({
+export async function seedReferenceData(db: ReferenceDataClient) {
+	const oidium = await db.disease.create({
 		data: {
 			name: "Oidium",
 			description: "Powdery mildew, a fungal disease affecting grapevines",
@@ -22,7 +26,7 @@ async function main() {
 		},
 	});
 
-	const peronospora = await prisma.disease.create({
+	const peronospora = await db.disease.create({
 		data: {
 			name: "Peronospora",
 			description: "Downy mildew, a fungal disease affecting grapevines",
@@ -31,61 +35,85 @@ async function main() {
 		},
 	});
 
-	// Create substances
-	const copper = await prisma.substance.create({
+	const copper = await db.substance.create({
 		data: {
 			name: "Copper",
-			maxDosage: 4, // kg/ha/year
+			maxDosage: 4,
 			diseases: {
 				connect: [{ id: peronospora.id }],
 			},
 		},
 	});
 
-	const sulfur = await prisma.substance.create({
+	const sulfur = await db.substance.create({
 		data: {
 			name: "Sulfur",
-			maxDosage: 10, // kg/ha/year
+			maxDosage: 10,
 			diseases: {
 				connect: [{ id: oidium.id }],
 			},
 		},
 	});
 
-	// create products
-	const MAX_APPLICATIONS = 6;
-	await prisma.product.create({
+	const copperProduct = await db.product.create({
 		data: {
 			name: "Pasta cafaro",
 			brand: "Pasta cafaro",
-			maxApplications: MAX_APPLICATIONS,
+			maxApplications: 6,
 			composition: {
-				create: [{ substanceId: copper.id, dose: 25.0 }],
+				create: [{ substanceId: copper.id, dose: 25 }],
 			},
 		},
 	});
-	const MAX_APPLICATIONS_SULFUR = 10;
-	await prisma.product.create({
+
+	const sulfurProduct = await db.product.create({
 		data: {
 			name: "Zolfo tiovit",
 			brand: "Zolfo tiovit",
-			maxApplications: MAX_APPLICATIONS_SULFUR,
+			maxApplications: 10,
 			composition: {
-				create: [{ substanceId: sulfur.id, dose: 80.0 }],
+				create: [{ substanceId: sulfur.id, dose: 80 }],
 			},
 		},
 	});
 
-	console.log("Seed data created:");
-	console.log("Diseases:", { oidium, peronospora });
-	console.log("Substances:", { copper, sulfur });
+	return {
+		copper,
+		copperProduct,
+		oidium,
+		peronospora,
+		sulfur,
+		sulfurProduct,
+	};
 }
 
-main()
-	.catch((e) => {
+async function main() {
+	const prisma = new PrismaClient();
+
+	// Delete existing data
+	console.log("Deleting existing data...");
+	try {
+		await cleanReferenceData(prisma);
+		console.log("Existing data deleted.");
+
+		const { copper, oidium, peronospora, sulfur } =
+			await seedReferenceData(prisma);
+
+		console.log("Seed data created:");
+		console.log("Diseases:", { oidium, peronospora });
+		console.log("Substances:", { copper, sulfur });
+	} finally {
+		await prisma.$disconnect();
+	}
+}
+
+const isSeedScript = process.argv.some(
+	(arg) => arg.endsWith("prisma/seed.ts") || arg.endsWith("prisma/seed.js"),
+);
+
+if (isSeedScript) {
+	main().catch((e) => {
 		console.error("Error seeding database:", e);
 		process.exit(1);
-	})
-	.finally(async () => {
-		await prisma.$disconnect();
 	});
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,7 @@ export async function cleanReferenceData(db: ReferenceDataClient) {
 }
 
 export async function seedReferenceData(db: ReferenceDataClient) {
+	// Create diseases
 	const oidium = await db.disease.create({
 		data: {
 			name: "Oidium",
@@ -38,7 +39,7 @@ export async function seedReferenceData(db: ReferenceDataClient) {
 	const copper = await db.substance.create({
 		data: {
 			name: "Copper",
-			maxDosage: 4,
+			maxDosage: 4, // kg/ha/year
 			diseases: {
 				connect: [{ id: peronospora.id }],
 			},
@@ -48,29 +49,32 @@ export async function seedReferenceData(db: ReferenceDataClient) {
 	const sulfur = await db.substance.create({
 		data: {
 			name: "Sulfur",
-			maxDosage: 10,
+			maxDosage: 10, // kg/ha/year
 			diseases: {
 				connect: [{ id: oidium.id }],
 			},
 		},
 	});
 
+	// create products
+	const MAX_APPLICATIONS = 6;
 	const copperProduct = await db.product.create({
 		data: {
 			name: "Pasta cafaro",
 			brand: "Pasta cafaro",
-			maxApplications: 6,
+			maxApplications: MAX_APPLICATIONS,
 			composition: {
 				create: [{ substanceId: copper.id, dose: 25 }],
 			},
 		},
 	});
 
+	const MAX_APPLICATIONS_SULFUR = 10;
 	const sulfurProduct = await db.product.create({
 		data: {
 			name: "Zolfo tiovit",
 			brand: "Zolfo tiovit",
-			maxApplications: 10,
+			maxApplications: MAX_APPLICATIONS_SULFUR,
 			composition: {
 				create: [{ substanceId: sulfur.id, dose: 80 }],
 			},

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,19 @@ Then run
 `npx vitest run`
 `npm run test:db:stop`
 
+## Run Playwright e2e tests
+
+The Playwright tests run the app against a dedicated Docker PostgreSQL database on `localhost:5434`. The suite seeds its own authorized test user, one Cinque Terre parcel, and dashboard treatments in `beforeAll`.
+
+```bash
+npm run test:e2e:install
+npm run test:e2e:db:start
+npm run test:e2e
+npm run test:e2e:db:stop
+```
+
+`npm run test:e2e:db:start` starts `docker-compose.e2e.yml`, waits for PostgreSQL, applies Prisma migrations, and generates the Prisma client. The Playwright config provides local non-production defaults for `DATABASE_URL`, `DIRECT_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `TEST_USER_EMAIL`, and `TEST_USER_PASSWORD`; override them in your shell only when you intentionally want a different e2e database.
+
 
 
 ## Deploy Agricolala

--- a/readme.md
+++ b/readme.md
@@ -48,8 +48,6 @@ Then run
 
 The Playwright tests run the app against a dedicated e2e PostgreSQL database. The suite seeds its own authorized test user, one parcel, and dashboard treatments in `beforeAll`.
 
-For local human runs with Docker Compose:
-
 ```bash
 npm run test:e2e:install
 npm run test:e2e:db:start
@@ -58,13 +56,6 @@ npm run test:e2e:db:stop
 ```
 
 `npm run test:e2e:db:start` starts `docker-compose.e2e.yml`, waits for PostgreSQL, applies Prisma migrations, and generates the Prisma client. The Playwright config provides local non-production defaults for `DATABASE_URL`, `DIRECT_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `TEST_USER_EMAIL`, and `TEST_USER_PASSWORD`. The e2e reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
-
-For Cursor Cloud agents, use native PostgreSQL instead of Docker:
-
-```bash
-npm run test:e2e:install
-npm run test:e2e:agent
-```
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ npm run test:e2e
 npm run test:e2e:db:stop
 ```
 
-`npm run test:e2e:db:start` starts `docker-compose.e2e.yml`, waits for PostgreSQL, applies Prisma migrations, and generates the Prisma client. The Playwright config provides local non-production defaults for `DATABASE_URL`, `DIRECT_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `TEST_USER_EMAIL`, and `TEST_USER_PASSWORD`; override them in your shell only when you intentionally want a different e2e database.
+`npm run test:e2e:db:start` starts `docker-compose.e2e.yml`, waits for PostgreSQL, applies Prisma migrations, and generates the Prisma client. The Playwright config provides local non-production defaults for `DATABASE_URL`, `DIRECT_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `TEST_USER_EMAIL`, and `TEST_USER_PASSWORD`. The e2e reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,9 @@ Then run
 
 ## Run Playwright e2e tests
 
-The Playwright tests run the app against a dedicated Docker PostgreSQL database on `localhost:5434`. The suite seeds its own authorized test user, one Cinque Terre parcel, and dashboard treatments in `beforeAll`.
+The Playwright tests run the app against a dedicated e2e PostgreSQL database. The suite seeds its own authorized test user, one parcel, and dashboard treatments in `beforeAll`.
+
+For local human runs with Docker Compose:
 
 ```bash
 npm run test:e2e:install
@@ -56,6 +58,13 @@ npm run test:e2e:db:stop
 ```
 
 `npm run test:e2e:db:start` starts `docker-compose.e2e.yml`, waits for PostgreSQL, applies Prisma migrations, and generates the Prisma client. The Playwright config provides local non-production defaults for `DATABASE_URL`, `DIRECT_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `TEST_USER_EMAIL`, and `TEST_USER_PASSWORD`. The e2e reset guard has no override and only allows localhost/127.0.0.1 on port 5434, local database names containing `e2e`, or the `postgres-e2e` Docker host.
+
+For Cursor Cloud agents, use native PostgreSQL instead of Docker:
+
+```bash
+npm run test:e2e:install
+npm run test:e2e:agent
+```
 
 
 

--- a/scripts/run-e2e-native.sh
+++ b/scripts/run-e2e-native.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+POSTGRES_USER="${E2E_POSTGRES_USER:-$(whoami)}"
+POSTGRES_DB="${E2E_POSTGRES_DB:-agraria_e2e}"
+DATABASE_URL_VALUE="postgresql://${POSTGRES_USER}@localhost/${POSTGRES_DB}?host=/var/run/postgresql&schema=public"
+
+sudo pg_ctlcluster 16 main start >/dev/null 2>&1 || true
+sudo -u postgres createuser --superuser "${POSTGRES_USER}" >/dev/null 2>&1 || true
+sudo -u postgres createdb -O "${POSTGRES_USER}" "${POSTGRES_DB}" >/dev/null 2>&1 || true
+
+export DATABASE_URL="${DATABASE_URL:-$DATABASE_URL_VALUE}"
+export DIRECT_URL="${DIRECT_URL:-$DATABASE_URL}"
+
+npx prisma migrate deploy
+npx prisma generate
+npm run test:e2e

--- a/scripts/setup-e2e-db.sh
+++ b/scripts/setup-e2e-db.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export DATABASE_URL="${DATABASE_URL:-postgresql://agraria:agraria@localhost:5434/agraria?schema=public}"
+export DIRECT_URL="${DIRECT_URL:-$DATABASE_URL}"
+
+docker compose -f docker-compose.e2e.yml up -d
+
+"$DIR/wait-until.sh" "pg_isready -h localhost -p 5434 -U agraria -d agraria" 60
+
+npx prisma migrate deploy
+npx prisma generate

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+	"version": 1,
+	"skills": {
+		"caveman": {
+			"source": "juliusbrussee/caveman",
+			"sourceType": "github",
+			"skillPath": "skills/caveman/SKILL.md",
+			"computedHash": "dfbf85749fd474feeb0bbe60c779795ecd5dbec0083299b56e68916bc3ddd8c9"
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Playwright e2e tests for dashboard chart data, parcel creation, and treatment creation.
- Add deterministic e2e database seeding and Docker Compose setup for local human runs.
- Add a native PostgreSQL e2e runner for Cursor Cloud agents so agents do not need Docker Compose.
- Reuse the reference-data seed helper from `prisma/seed.ts` inside the e2e fixture setup while preserving seed comments and constants.
- Keep human e2e instructions in `readme.md` and agent e2e instructions in `AGENTS.md`.
- Use realistic 20m x 20m-ish e2e parcel dimensions with copper doses derived from a 10-treatment season under the 4kg/ha annual cap.
- Use a generic e2e parcel fixture name with no location-specific naming in code.
- Fix parcel dialog altitude state so the add-parcel flow has no visible dev overlay.
- Run the Playwright e2e suite in the existing `Tests` GitHub Actions workflow.
- Use accessible chart figure/name selectors instead of `data-testid`, and document accessible selector preference for future tests.
- Translate the add-treatment floating button accessible label and keep the e2e selector aligned with localized UI text.
- Remove the e2e reset override and hard-limit database resets to explicit local e2e targets.

## Testing
- `npm run test:e2e:install` passed.
- `npm run test:e2e:db:start` could not use Docker in this VM because the Docker socket was unavailable; local Docker Compose workflow remains documented and committed for humans.
- `npm run seed` passed against the throwaway native PostgreSQL e2e database.
- `npm run test:e2e:agent` passed using native PostgreSQL in this Cursor Cloud VM.
- `npx prisma migrate deploy` passed against a throwaway native PostgreSQL e2e database.
- `npm run tsc` passed.
- `npm run lint` passed with one pre-existing warning in `hooks/use-toast.ts`.
- `npx biome check .` passed.
- `npm run test:e2e` passed against the throwaway native PostgreSQL e2e database.
- `python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path(".github/workflows/test.yml").read_text()); print("workflow yaml ok")'` passed.
- Remote database guard check passed: a fake `prod.example.com/prod` `DATABASE_URL` was rejected before any reset work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a16e3633-c469-4112-a23a-1e466febcdc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a16e3633-c469-4112-a23a-1e466febcdc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

